### PR TITLE
Fix issue with file upload paths

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -205,12 +205,17 @@ class GuestEntryController extends Controller
             $path = '/' . $uploadedFile->storeAs(
                 isset($field->config()['folder'])
                     ? $field->config()['folder']
-                    : $assetContainer->diskPath(),
+                    : '',
                 now()->timestamp . '-' . $uploadedFile->getClientOriginalName(),
                 $assetContainer->diskHandle()
             );
 
-            $files[] = str_replace($assetContainer->diskPath(), '', $path);
+            // Does path start with a '/'? If so, strip it off.
+            if (substr($path, 0, 1) === '/') {
+                $path = substr($path, 1);
+            }
+
+            $files[] = $path;
         }
 
         if (count($files) === 0) {


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes an issue where files would be created in weird, duplicate paths like `/Users/duncan/Sites/some-site.com/public/assets/Users/duncan/Sites/some-site.com/public/assets`

The issue was that we were using the disk path as the path for the storing the file inside the filesystem. This PR also strips out the initial `/` in the file path, in the case that it's present.

Fixes #24