### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.3",
-        "statamic/cms": "^6.0"
+        "statamic/cms": "^6.5"
     },
     "require-dev": {
         "pestphp/pest": "^3.0 || ^4.1",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^3.0 || ^4.1",
-        "orchestra/testbench": "^10.8 || ^12.0",
+        "orchestra/testbench": "^10.8 || ^11.0",
         "spatie/test-time": "^1.2",
         "laravel/pint": "^1.18"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^3.0 || ^4.1",
-        "orchestra/testbench": "^10.8",
+        "orchestra/testbench": "^10.8 || ^12.0",
         "spatie/test-time": "^1.2",
         "laravel/pint": "^1.18"
     },
@@ -42,5 +42,7 @@
             "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This pull request adds Laravel 13 support to Guest Entries. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

Depends on:
* [x] https://github.com/statamic/cms/pull/13870