### PR TITLE
[4.x] Return 422 for invalid form parameters

### DIFF
--- a/src/Exceptions/InvalidFormParametersException.php
+++ b/src/Exceptions/InvalidFormParametersException.php
@@ -2,7 +2,12 @@
 
 namespace DuncanMcClean\GuestEntries\Exceptions;
 
-class InvalidFormParametersException extends \Exception
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class InvalidFormParametersException extends HttpException
 {
-    //
+    public function __construct()
+    {
+        parent::__construct(422, 'Invalid form parameters.');
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue where requests with invalid or missing encrypted form parameters would return a 500 error.

This was happening because `InvalidFormParametersException` extended the base `\Exception` class, which Laravel treats as an unhandled exception and returns a 500 response.

This PR fixes it by extending Symfony's `HttpException` with a 422 status code instead, so Laravel returns a proper "Unprocessable Entity" response.